### PR TITLE
Undo prohibited changes to older migrations

### DIFF
--- a/packages/server/src/db/migrations/20220407024326-create-tree-labels-table.js
+++ b/packages/server/src/db/migrations/20220407024326-create-tree-labels-table.js
@@ -29,7 +29,7 @@ module.exports = {
 
       // Create through table.
       await queryInterface.createTable(
-        "tree_census_labels",
+        "tree_tree_label",
         {
           id: {
             type: Sequelize.UUID,
@@ -70,7 +70,7 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable("tree_census_labels");
+    await queryInterface.dropTable("tree_tree_label");
     await queryInterface.dropTable("tree_labels");
   },
 };

--- a/packages/server/src/db/migrations/20220410191551-tree-and-census-entries.js
+++ b/packages/server/src/db/migrations/20220410191551-tree-and-census-entries.js
@@ -166,6 +166,13 @@ module.exports = {
        *
        */
 
+      // Rename table.
+      await queryInterface.renameTable(
+        "tree_tree_label",
+        "tree_census_labels",
+        { transaction }
+      );
+
       // Update tree_census_labels to point to tree_census.
       await queryInterface.addColumn(
         "tree_census_labels",


### PR DESCRIPTION
I shouldn't have made changes to the existing migration file `20220407024326-create-tree-labels-table`. I undo that change, and instead modify the new migration file I added.